### PR TITLE
Update python version from 3.6 to 3.8

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
   - pytorch
 dependencies:
-  - python>=3.6
+  - python>=3.8
   - pip
   - numpy
   - scipy


### PR DESCRIPTION
In some parts of the code ": =" is used, which only works in python> = 3.8